### PR TITLE
Improve unsupported tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,107 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 # C extensions
 *.so
 
+# PyCharm
+.idea/
+
 # Distribution / packaging
 .Python
 build/

--- a/README.md
+++ b/README.md
@@ -42,70 +42,8 @@ By default tracing functionality is disabled, you may use the logging functional
 
 There are four ways to implement tracing, depending on your use case:
 #### `Tracer` class
-Use this if you are not using Flask or gRPC, or if you would like to use the library for purposes other than to trace individual requests.
-Initialise the Tracer class _once_ in your app, and it is recommended you do it in a separate file to avoid cyclic import errors.
-```python
-# app/trace.py
-from app.log import logger_factory
-from logtracer.tracing import Tracer
-
-enable_trace_posting = os.getenv('ENABLE_TRACE_POSTING', 'false') == 'true'
-tracer = Tracer(logger_factory, post_spans_to_stackdriver_api=enable_trace_posting)
-tracer.set_logging_level('DEBUG') # 'INFO' recommended in production
-```
-Using the Tracer instance to manage spans:
-```python
-from app.trace.py import tracer
-from app.log import logger_factory
-
-logger = logger_factory.get_logger(__name__)
-
-logger.info('Outside of span')
-
-tracer.start_traced_span(headers, 'example-span')
-logger.info('In span')
-
-tracer.start_traced_subspan('example-sub-span')
-logger.info('In sub span')
-
-tracer.start_traced_subspan('example-sub-sub-span')
-logger.info('In sub sub span')
-
-# use wrapped requests library which injects tracing headers
-tracer.requests.get('http://example-traced-get.com')
-
-tracer.end_traced_subspan(exclude_from_posting=False)
-
-tracer.end_traced_subspan(exclude_from_posting=False)
-
-tracer.end_traced_span(exclude_from_posting=False)
-
-```
-Or, using context managers:
-
-```python
-from app.trace.py import tracer
-from app.log import logger_factory
-from logtracer.tracing import SpanContext, SubSpanContext
-
-...
-
-logger = logger_factory.get_logger(__name__)
-
-logger.info('Outside of span')
-with SpanContext(tracer, headers, 'example-span'):
-    logger.info('In span')
-    with SubSpanContext(tracer, 'example-sub-span'):
-        logger.info('In sub span')
-        with SubSpanContext(tracer, 'example-sub-sub-span'):
-            logger.info('In sub sub span')
-            tracer.requests.get('http://example-traced-get.com')
-
-```
-The `Tracer` class (and therefore the `FlaskTracer`, `GRPCTracer` and `MixedTracer` classes) have a `requests` property. This wraps the standard
-requests library to automatically inject the span values into any outgoing `get`, `post`, `update`, etc. requests.
-
-The `FlaskTracer`, `GRPCTracer` and `MixedTracer` classes inherit from the `Tracer` class, and wrap these features to make implementation simpler.
+See [Tracer](logtracer/tracing). This is the main tracing class - the `FlaskTracer`, `GRPCTracer` and `MixedTracer` classes inherit from the this class.
+Usually you don't want to use this class directly, use one of the others instead.
    
 #### `MixedTracer` class
 See [MixedTracer](logtracer/helpers/mixed), use with a Flask app that calls gRPC or HTTP services. Inherits from both

--- a/logtracer/helpers/flask/README.md
+++ b/logtracer/helpers/flask/README.md
@@ -70,8 +70,8 @@ def exception_handler(e):
 
 ### Tracing Outbound Requests
 
-#### HTTP
-To trace outbound HTTP requests, use the wrapped `requests` library included with the tracer:
+#### HTTP 
+To trace outbound HTTP requests to another service with `logtracer` installed, use the wrapped `requests` library included with the tracer:
 
 ```python
 from app.trace import flask_tracer
@@ -84,5 +84,35 @@ flask_tracer.requests.post('http://example-post.com', data={'data':'test'})
 ...
 ```
 
+#### HTTP (to a service without `logtracer`)
+
+```python
+from app.trace import flask_tracer
+
+...
+
+flask_tracer.unsupported_requests.get('http://example-get.com')
+flask_tracer.unsupported_requests.post('http://example-post.com', data={'data':'test'})
+
+...
+```
+
 #### GRPC
 To trace an outgoing gRPC request, use the [Mixed Tracer](../mixed) class instead.
+
+#### Other
+To trace anything else, use the `SubSpanContext`.
+```python
+from app.trace import flask_tracer
+from app.log import logger_factory
+from logtracer.tracing import SubSpanContext
+
+...
+
+logger = logger_factory.get_logger(__name__)
+
+logger.info('Outside of a subspan')
+with SubSpanContext(flask_tracer, 'example-span'):
+    logger.info('In a subspan, trace a function or anything else here.')
+
+```

--- a/logtracer/helpers/flask/tracing.py
+++ b/logtracer/helpers/flask/tracing.py
@@ -3,7 +3,7 @@ import functools
 from flask import request
 
 from logtracer.helpers.flask.path_exclusion import _is_path_excluded
-from logtracer.tracing import Tracer
+from logtracer.tracing.tracer import Tracer
 
 
 class FlaskTracer(Tracer):

--- a/logtracer/helpers/flask/tracing.py
+++ b/logtracer/helpers/flask/tracing.py
@@ -3,7 +3,7 @@ import functools
 from flask import request
 
 from logtracer.helpers.flask.path_exclusion import _is_path_excluded
-from logtracer.tracing.tracer import Tracer
+from logtracer.tracing import Tracer
 
 
 class FlaskTracer(Tracer):

--- a/logtracer/helpers/grpc/README.md
+++ b/logtracer/helpers/grpc/README.md
@@ -75,6 +75,21 @@ grpc_tracer.requests.post('http://example-post.com', data={'data':'test'})
 ...
 ```
 
+
+#### HTTP (to a service without `logtracer`)
+
+```python
+from app.trace import grpc_tracer
+
+...
+
+grpc_tracer.unsupported_requests.get('http://example-get.com')
+grpc_tracer.unsupported_requests.post('http://example-post.com', data={'data':'test'})
+
+...
+```
+
+
 #### gRPC
 ```python
 import grpc
@@ -88,4 +103,21 @@ stub = DemoServiceStub(intercept_channel)
 
 message = EmptyMessage()
 stub.DemoRPC(message)
+```
+
+#### Other
+To trace anything else, use the `SubSpanContext`.
+```python
+from app.trace import grpc_tracer
+from app.log import logger_factory
+from logtracer.tracing import SubSpanContext
+
+...
+
+logger = logger_factory.get_logger(__name__)
+
+logger.info('Outside of a subspan')
+with SubSpanContext(grpc_tracer, 'example-span'):
+    logger.info('In a subspan, trace a function or anything else here.')
+
 ```

--- a/logtracer/helpers/grpc/tracing.py
+++ b/logtracer/helpers/grpc/tracing.py
@@ -5,7 +5,7 @@ from grpc._cython.cygrpc import _Metadatum
 from grpc._interceptor import _ClientCallDetails
 
 from logtracer.helpers.grpc.redact import redact_request
-from logtracer.tracing.tracer import Tracer
+from logtracer.tracing import Tracer
 
 B3_VALUES_KEY = 'b3-values'
 

--- a/logtracer/helpers/grpc/tracing.py
+++ b/logtracer/helpers/grpc/tracing.py
@@ -5,7 +5,7 @@ from grpc._cython.cygrpc import _Metadatum
 from grpc._interceptor import _ClientCallDetails
 
 from logtracer.helpers.grpc.redact import redact_request
-from logtracer.tracing import Tracer
+from logtracer.tracing.tracer import Tracer
 
 B3_VALUES_KEY = 'b3-values'
 

--- a/logtracer/helpers/mixed/README.md
+++ b/logtracer/helpers/mixed/README.md
@@ -37,8 +37,22 @@ tracer.requests.post('http://example-post.com', data={'data':'test'})
 ...
 ```
 
+#### HTTP (to a service without `logtracer`)
+
+```python
+from app.trace import tracer
+
+...
+
+tracer.unsupported_requests.get('http://example-get.com')
+tracer.unsupported_requests.post('http://example-post.com', data={'data':'test'})
+
+...
+```
+
+
 #### gRPC
-User the channel interceptor inherited from GRPCTracer:
+User the channel interceptor (inherited from GRPCTracer):
 ```python
 import grpc
 from app.trace import tracer
@@ -51,4 +65,21 @@ stub = DemoServiceStub(intercept_channel)
 
 message = EmptyMessage()
 stub.DemoRPC(message)
+```
+
+#### Other
+To trace anything else, use the `SubSpanContext`.
+```python
+from app.trace import tracer
+from app.log import logger_factory
+from logtracer.tracing import SubSpanContext
+
+...
+
+logger = logger_factory.get_logger(__name__)
+
+logger.info('Outside of a subspan')
+with SubSpanContext(tracer, 'example-span'):
+    logger.info('In a subspan, trace a function or anything else here.')
+
 ```

--- a/logtracer/jsonlog.py
+++ b/logtracer/jsonlog.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pythonjsonlogger import jsonlogger
 
 from logtracer.exceptions import SpanNotStartedError
-from logtracer.tracing import B3_SPAN_ID, B3_TRACE_ID
+from logtracer.tracing.tracer import B3_SPAN_ID, B3_TRACE_ID
 
 LOG_SEVERITIES = {
     'DEBUG': 'DEBUG',

--- a/logtracer/jsonlog.py
+++ b/logtracer/jsonlog.py
@@ -131,7 +131,9 @@ class JSONLoggerFactory:
         root_logger.handlers = []
         root_logger.addHandler(handler)
 
-    def get_logger(self, module_name=''):
+    def get_logger(self, module_name='', level='INFO'):
         """Use this function to get the logger throughout your app."""
         module_name = f".{module_name}" if module_name else module_name
-        return logging.getLogger(f'{self.service_name}{module_name}')
+        logger = logging.getLogger(f'{self.service_name}{module_name}')
+        logger.setLevel(level)
+        return logger

--- a/logtracer/tracing/README.md
+++ b/logtracer/tracing/README.md
@@ -1,0 +1,114 @@
+# Tracer
+>Use the Tracer class if you are _not_ using Flask or gRPC, or if you would like to use the library for purposes other than to trace individual requests.
+
+## Implementation Guide
+Before following these instructions, make sure to follow the instructions in the [main readme](../README.md).
+Example code exists in `/examples`, look at these for working implementations.
+Initialise the Tracer class _once_ in your app, and it is recommended you do it in a separate file to avoid cyclic import errors.
+
+```python
+# app/trace.py
+from app.log import logger_factory
+from logtracer.tracing import Tracer
+
+enable_trace_posting = os.getenv('ENABLE_TRACE_POSTING', 'false') == 'true'
+tracer = Tracer(logger_factory, post_spans_to_stackdriver_api=enable_trace_posting)
+tracer.set_logging_level('DEBUG') # 'INFO' recommended in production
+```
+Using the Tracer instance to manage spans:
+```python
+from app.trace.py import tracer
+from app.log import logger_factory
+
+logger = logger_factory.get_logger(__name__)
+
+logger.info('Outside of span')
+
+tracer.start_traced_span(headers, 'example-span')
+logger.info('In span')
+
+tracer.start_traced_subspan('example-sub-span')
+logger.info('In sub span')
+
+tracer.start_traced_subspan('example-sub-sub-span')
+logger.info('In sub sub span')
+
+tracer.end_traced_subspan(exclude_from_posting=False)
+
+tracer.end_traced_subspan(exclude_from_posting=False)
+
+tracer.end_traced_span(exclude_from_posting=False)
+
+```
+Or, using context managers:
+
+```python
+from app.trace.py import tracer
+from app.log import logger_factory
+from logtracer.tracing import SpanContext, SubSpanContext
+
+...
+
+logger = logger_factory.get_logger(__name__)
+
+logger.info('Outside of span')
+with SpanContext(tracer, headers, 'example-span'):
+    logger.info('In span')
+    with SubSpanContext(tracer, 'example-sub-span'):
+        logger.info('In sub span')
+        with SubSpanContext(tracer, 'example-sub-sub-span'):
+            logger.info('In sub sub span')
+
+```
+The `Tracer` class (and therefore the `FlaskTracer`, `GRPCTracer` and `MixedTracer` classes) have a `requests` property. This wraps the standard
+requests library to automatically inject the span values into any outgoing `get`, `post`, `update`, etc. requests.
+
+
+### Tracing Outbound Requests
+
+#### HTTP 
+To trace outbound HTTP requests to another service with `logtracer` installed, use the wrapped `requests` library included with the tracer:
+
+```python
+from app.trace import tracer
+
+...
+
+tracer.requests.get('http://example-get.com')
+tracer.requests.post('http://example-post.com', data={'data':'test'})
+
+...
+```
+
+#### HTTP (to a service without `logtracer`)
+
+```python
+from app.trace import tracer
+
+...
+
+tracer.unsupported_requests.get('http://example-get.com')
+tracer.unsupported_requests.post('http://example-post.com', data={'data':'test'})
+
+...
+```
+
+#### GRPC
+To trace an outgoing gRPC request, use the [Mixed Tracer](../mixed) or [gRPC Tracer](../grpc) class instead.
+
+#### Other
+To trace anything else, use the `SubSpanContext`.
+```python
+from app.trace import tracer
+from app.log import logger_factory
+from logtracer.tracing import SubSpanContext
+
+...
+
+logger = logger_factory.get_logger(__name__)
+
+logger.info('Outside of a subspan')
+with SubSpanContext(tracer, 'example-span'):
+    logger.info('In a subspan, trace a function or anything else here.')
+
+```

--- a/logtracer/tracing/__init__.py
+++ b/logtracer/tracing/__init__.py
@@ -1,0 +1,2 @@
+from logtracer.tracing.tracer import Tracer
+from logtracer.tracing.context_managers import SpanContext, SubSpanContext

--- a/logtracer/tracing/_utils.py
+++ b/logtracer/tracing/_utils.py
@@ -1,0 +1,59 @@
+import os
+import time
+from binascii import hexlify
+
+from google.protobuf.timestamp_pb2 import Timestamp
+
+
+def post_span(stackdriver_trace_client, span_info):
+    """Post span to Stackdriver Trace API."""
+    stackdriver_trace_client.create_span(**span_info)
+
+
+def get_timestamp():
+    """Get timestamp in a format Stackdriver Trace accepts it."""
+    now = time.time()
+    seconds, nanos = to_seconds_and_nanos(now)
+    timestamp = Timestamp(seconds=seconds, nanos=nanos)
+    return timestamp
+
+
+def to_seconds_and_nanos(fractional_seconds):
+    """Convert fractional seconds to seconds and nanoseconds."""
+    seconds = int(fractional_seconds)
+    nanos = int((fractional_seconds - seconds) * 10 ** 9)
+    return seconds, nanos
+
+
+def truncate_str(str_to_truncate, limit):
+    """Truncate a string if exceed limit and record the truncated bytes count."""
+    str_bytes = str_to_truncate.encode('utf-8')
+    trunc = {
+        'value': str_bytes[:limit].decode('utf-8', errors='ignore'),
+        'truncated_byte_count': len(str_bytes) - len(str_bytes[:limit]),
+    }
+    return trunc
+
+
+def generate_identifier(identifier_length):
+    """
+    Generates a new, random identifier in B3 format.
+    Arguments:
+        identifier_length (int): length of identifier to generate
+    Returns:
+        (str): A 64-bit random identifier, rendered as a hex String.
+    """
+    if not is_power2(identifier_length):
+        raise ValueError('ID length must be a positive non-zero power of 2')
+
+    bit_length = identifier_length * 4
+    byte_length = int(bit_length / 8)
+    identifier = os.urandom(byte_length)
+    return hexlify(identifier).decode('ascii')
+
+
+def is_power2(num):
+    """
+    States if a number is a power of two
+    """
+    return num != 0 and ((num & (num - 1)) == 0)

--- a/logtracer/tracing/context_managers.py
+++ b/logtracer/tracing/context_managers.py
@@ -1,0 +1,27 @@
+class SpanContext:
+    def __init__(self, tracer, incoming_headers, span_name, exclude_from_posting=False):
+        """Context manager for creating a span."""
+        self.tracer = tracer
+        self.span_name = span_name
+        self.exclude = exclude_from_posting
+        self.incoming_headers = incoming_headers
+
+    def __enter__(self):
+        self.tracer.start_traced_span(self.incoming_headers, self.span_name)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.tracer.end_traced_span(self.exclude)
+
+
+class SubSpanContext:
+    def __init__(self, tracer, span_name, exclude_from_posting=False):
+        """Context manager for creating a subspan."""
+        self.tracer = tracer
+        self.span_name = span_name,
+        self.exclude = exclude_from_posting
+
+    def __enter__(self):
+        self.tracer.start_traced_subspan(self.span_name)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.tracer.end_traced_subspan(self.exclude)

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,10 @@ if __name__ == "__main__":
             'wheel'
         ],
         tests_require=[
-            'pytest',
-            'pytest-runner',
-            'flake8',
-            'pytest-cov', ],
+            'pytest==3.6.2',
+            'pytest-runner==4.2',
+            'flake8==3.5.0',
+            'pycodestyle<2.4.0',
+            'pytest-cov==2.5.1',
+        ],
     )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 if __name__ == "__main__":
     setup(
         name="logtracer",
-        version="0.3b",
+        version="0.3.1",
         author="Datalab",
         author_email="datalab@bbc.co.uk",
         description="Adds distributed tracing information to logger output and sends traces to the Stackdriver "
@@ -22,9 +22,9 @@ if __name__ == "__main__":
             "Operating System :: OS Independent",
         ],
         install_requires=[
-            'python-json-logger==0.1.9',
-            'google-cloud-trace==0.19.0',
-            'requests==2.19.1'
+            'python-json-logger>=0.1.9',
+            'google-cloud-trace>=0.19.0',
+            'requests>=2.18'
         ],
         test_suite="tests",
         setup_requires=[

--- a/tests/test_requests_wrapper.py
+++ b/tests/test_requests_wrapper.py
@@ -1,11 +1,29 @@
 from unittest.mock import MagicMock, patch
 
-from logtracer.requests_wrapper import RequestsWrapper
+
+@patch('logtracer.requests_wrapper.requests.get')
+@patch('logtracer.requests_wrapper.requests.post')
+@patch('logtracer.tracing.SubSpanContext')
+def test_unsupported_request_mapper(m_subspan, m_requests_post, m_requests_get):
+    from logtracer.requests_wrapper import UnsupportedRequestsWrapper
+
+    m_tracer = MagicMock()
+    requests = UnsupportedRequestsWrapper(m_tracer)
+
+    requests.get('http://example.com', headers={'example': 'headers'})
+    m_requests_get.assert_called_with('http://example.com', headers={'example': 'headers'})
+    m_subspan.assert_called_with(m_tracer, 'http://example.com')
+
+    requests.post('http://example.com', headers={'example': 'headers'})
+    m_requests_post.assert_called_with('http://example.com', headers={'example': 'headers'})
+    m_subspan.assert_called_with(m_tracer, 'http://example.com')
 
 
 @patch('logtracer.requests_wrapper.requests.get')
 @patch('logtracer.requests_wrapper.requests.post')
 def test_request_mapper(m_requests_post, m_requests_get):
+    from logtracer.requests_wrapper import RequestsWrapper
+
     m_tracer = MagicMock()
     m_tracer.generate_new_traced_subspan_values.return_value = {'tracing': 'headers'}
     requests = RequestsWrapper(m_tracer)
@@ -14,4 +32,5 @@ def test_request_mapper(m_requests_post, m_requests_get):
     m_requests_get.assert_called_with('http://example.com', headers={'example': 'headers', 'tracing': 'headers'})
 
     requests.post('http://example.com', headers={'example': 'headers'}, data={})
-    m_requests_post.assert_called_with('http://example.com', data={}, headers={'example': 'headers',  'tracing': 'headers'})
+    m_requests_post.assert_called_with('http://example.com', data={},
+                                       headers={'example': 'headers', 'tracing': 'headers'})

--- a/tests/test_tracing_context_managers.py
+++ b/tests/test_tracing_context_managers.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from logtracer.exceptions import SpanNotStartedError
+from logtracer.tracing import SpanContext, SubSpanContext
+
+
+def test_spancontext():
+    m_tracer = MagicMock()
+    with SpanContext(m_tracer, {'test': 'headers'}, 'test_span_name', exclude_from_posting='test_exclude_bool'):
+        m_tracer.start_traced_span.assert_called_with({'test': 'headers'}, 'test_span_name')
+        assert not m_tracer.end_traced_span.called
+    m_tracer.end_traced_span.assert_called_with('test_exclude_bool')
+
+
+def test_subspancontext_no_span():
+    m_tracer = MagicMock()
+    m_tracer.start_traced_subspan.side_effect = SpanNotStartedError
+    with pytest.raises(SpanNotStartedError):
+        with SubSpanContext(m_tracer, 'test_span_name', 'test_exclude_bool'):
+            pass

--- a/tests/test_tracing_utils.py
+++ b/tests/test_tracing_utils.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from logtracer.tracing._utils import post_span, get_timestamp, to_seconds_and_nanos, truncate_str
+
+MODULE_PATH = 'logtracer.tracing._utils.'
+
+
+def test_post_span():
+    m_trace_client = MagicMock()
+    post_span(m_trace_client, {"info": "test_span_info"})
+    m_trace_client.create_span.assert_called_with(info="test_span_info")
+
+
+@patch(MODULE_PATH + 'to_seconds_and_nanos')
+@patch(MODULE_PATH + 'time')
+def test_get_timestamp(m_time, m_to_secs_and_nanos):
+    m_time.time.return_value = 'test_time'
+    m_to_secs_and_nanos.return_value = (100, 200)
+
+    timestamp = get_timestamp()
+
+    m_to_secs_and_nanos.assert_called_with('test_time')
+    assert timestamp == Timestamp(seconds=100, nanos=200)
+
+
+def test_to_seconds_and_nanos():
+    seconds, nanos = to_seconds_and_nanos(1532962140.8755891)
+
+    assert seconds == 1532962140
+    assert nanos == 875589132
+
+
+def test_truncate_str():
+    shortstr = 'short'
+    trunc_obj = truncate_str(shortstr, limit=10)
+    assert trunc_obj == {'value': 'short', 'truncated_byte_count': 0}
+
+    longstr = 'kindoflongstring'
+    trunc_obj = truncate_str(longstr, limit=10)
+    assert trunc_obj == {'value': 'kindoflong', 'truncated_byte_count': 6}


### PR DESCRIPTION
Add another wrapper for the `requests` library that handles tracing for outbound requests to a service without `logtracer` installed.