### PR TITLE
Datalab 790: Fix request package security vulnerability

### DIFF
--- a/requirements.examples.txt
+++ b/requirements.examples.txt
@@ -1,4 +1,4 @@
-requests==2.19.1
+requests>=2.20.0
 Flask==1.0.2
 grpcio==1.10.0
 grpcio-tools==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         install_requires=[
             'python-json-logger>=0.1.9',
             'google-cloud-trace>=0.19.0',
-            'requests>=2.18',
+            'requests>=2.20.0',
             'protobuf>=3.6.0'
         ],
         test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 if __name__ == "__main__":
     setup(
         name="logtracer",
-        version="0.3.2",
+        version="0.3.3",
         author="Datalab",
         author_email="datalab@bbc.co.uk",
         description="Adds distributed tracing information to logger output and sends traces to the Stackdriver "


### PR DESCRIPTION
Updated request version and incremented logtracer version

Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.