### PR TITLE
DATALAB-1000: fix to be able to deal with EnvironHeaders class (cast to dict)

### DIFF
--- a/logtracer/tracing/tracer.py
+++ b/logtracer/tracing/tracer.py
@@ -115,8 +115,9 @@ class Tracer:
         self.logger.debug(f'Span started {self.memory.current_span_id}')
 
     def _extract_google_trace_headers_if_present(self, incoming_headers):
+        """Extract Google tracing headers from incoming requests if they are present."""
         if B3_TRACE_ID not in incoming_headers and GOOGLE_LOAD_BALANCER_TRACE_HEADERS in incoming_headers:
-            incoming_headers = deepcopy(incoming_headers)
+            incoming_headers = dict(incoming_headers)
             try:
                 traceid, spanid_with_params = incoming_headers.get(GOOGLE_LOAD_BALANCER_TRACE_HEADERS, '').split('/')
                 if ';' in spanid_with_params:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 if __name__ == "__main__":
     setup(
         name="logtracer",
-        version="0.3.4",
+        version="0.3.5",
         author="Datalab",
         author_email="datalab@bbc.co.uk",
         description="Adds distributed tracing information to logger output and sends traces to the Stackdriver "


### PR DESCRIPTION
Testing v0.3.4 with snowdrop failed because the incoming headers object couldn't be copied and was immutable. This fix casts it to a dict.